### PR TITLE
Use the original property instead of depending on OC for isAdmin

### DIFF
--- a/lib/user.ts
+++ b/lib/user.ts
@@ -1,9 +1,3 @@
-/// <reference types="@nextcloud/typings" />
-
-declare var OC: Nextcloud.v23.OC
-	| Nextcloud.v24.OC
-	| Nextcloud.v25.OC;
-
 const getAttribute = (el: HTMLHeadElement | undefined, attribute: string): string | null => {
 	if (el) {
 		return el.getAttribute(attribute)
@@ -40,7 +34,7 @@ export function getCurrentUser(): NextcloudUser | null {
 	currentUser = {
 		uid,
 		displayName: getAttribute(head, 'data-user-displayname'),
-		isAdmin: (typeof OC === 'undefined') ? false : OC.isUserAdmin(),
+		isAdmin: !!(window as any)._oc_isadmin,
 	} as NextcloudUser
 
 	return currentUser


### PR DESCRIPTION
Declaration of `OC.isUserAdmin`: https://github.com/nextcloud/server/blob/6714e51b0ce25fe5d9223279a9484abd8c00f85e/core/src/OC/admin.js#L32
Declaration of `_oc_isadmin`: https://github.com/nextcloud/server/blob/6714e51b0ce25fe5d9223279a9484abd8c00f85e/lib/private/Template/JSConfigHelper.php#L187
