### PR TITLE
feat: Add CSP nonce handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,19 @@ Nextcloud helpers related to authentication and the current user
 ## Install
 
 ```sh
-yarn add @nextcloud/auth
-```
-
-```sh
 npm install @nextcloud/auth --save
 ```
 
-## Usage
+```sh
+yarn add @nextcloud/auth
+```
 
+## Usage
+For detailed information check [the package documentation](https://nextcloud-libraries.github.io/nextcloud-auth/index.html).
+
+One example usage to get the current user:
 ```ts
-import {
-  getRequestToken,
-  getCurrentUser,
-  onRequestTokenUpdate,
-} from '@nextcloud/auth'
+import { getCurrentUser } from '@nextcloud/auth'
 
 const user = getCurrentUser()
 
@@ -35,5 +33,3 @@ if (user.isAdmin) {
   // do something
 }
 ```
-
-For more information check [nextcloud-libraries.github.io/nextcloud-auth](https://nextcloud-libraries.github.io/nextcloud-auth/index.html)

--- a/lib/csp-nonce.ts
+++ b/lib/csp-nonce.ts
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { getRequestToken } from './requesttoken'
+
+/**
+ * Get the CSP nonce for script loading
+ *
+ * @return Current nonce if set
+ * @example When using webpack this can be used to allow webpack to dynamically load additional modules:
+ * ```js
+ * import { getCSPNonce } from '@nextcloud/auth'
+ *
+ * __webpack_nonce__ = getCSPNonce()
+ * ```
+ */
+export function getCSPNonce(): string | undefined {
+	const meta = document?.querySelector<HTMLMetaElement>('meta[name="csp-nonce"]')
+	// backwards compatibility with older Nextcloud versions
+	if (!meta) {
+		const token = getRequestToken()
+		return token ? btoa(token) : undefined
+	}
+	return meta.nonce
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,6 +5,7 @@
 export type { CsrfTokenObserver } from './requesttoken'
 export type { NextcloudUser } from './user'
 
+export { getCSPNonce } from './csp-nonce'
+export { getGuestNickname, setGuestNickname } from './guest'
 export { getRequestToken, onRequestTokenUpdate } from './requesttoken'
 export { getCurrentUser } from './user'
-export { getGuestNickname, setGuestNickname } from './guest'

--- a/test/csp-nonce.test.ts
+++ b/test/csp-nonce.test.ts
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+import { randomBytes } from 'crypto'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+/**
+ * Mock `<meta>` element with nonce
+ */
+function mockNonce() {
+	const nonce = randomBytes(16).toString('base64')
+	const el = document.createElement('meta')
+	el.name = 'csp-nonce'
+	el.nonce = nonce
+	document.head.appendChild(el)
+	return nonce
+}
+
+describe('CSP nonce', () => {
+	beforeEach(() => {
+		vi.resetModules()
+		// reset document
+		document.head.innerHTML = ''
+		delete document.head.dataset.requesttoken
+	})
+
+	test('read nonce from meta element', async () => {
+		const { getCSPNonce } = await import('../lib')
+		const nonce = mockNonce()
+		expect(getCSPNonce()).toBe(nonce)
+	})
+
+	test('prefer nonce over csrf token', async () => {
+		const { getCSPNonce } = await import('../lib')
+
+		const nonce = mockNonce()
+		document.head.dataset.requesttoken = 'csrf-token'
+		expect(getCSPNonce()).toBe(nonce)
+	})
+
+	test('fall back to csrf token for legacy Nextcloud versions', async () => {
+		const { getCSPNonce } = await import('../lib')
+
+		document.head.dataset.requesttoken = 'csrf-token'
+		expect(getCSPNonce()).toBe(btoa('csrf-token'))
+	})
+
+	test('return undefined if neither csp nonce nor csrf token is set', async () => {
+		const { getCSPNonce } = await import('../lib')
+
+		expect(getCSPNonce()).toBe(undefined)
+	})
+})


### PR DESCRIPTION
Add function for getting the CSP nonce, as this is not always the same as the CSRF token.
This requires this server PR first: https://github.com/nextcloud/server/pull/43573 (well basically both require each other)