### PR TITLE
chore: Prepare v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.4.0 - 2024-08-13
+### Added
+* feat: Add CSP nonce handling (`getCSPNonce`)
+* feat: add guest nickname handling
+
+### Changed
+* Add SPDX headers
+* docs: Fix link to online docs
+* test: Add missing tests for request token
+* chore(deps): Bump @nextcloud/event-bus to 3.3.1
+* Updated development dependencies
+
 ## 2.3.0 - 2024-04-22
 ### Added
 * feat: Use vite for transpiling and vitest for testing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/auth",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/auth",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/browser-storage": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/auth",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Nextcloud helpers related to authentication and the current user",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## 2.4.0 - 2024-08-13
### Added
* feat: Add CSP nonce handling (`getCSPNonce`)
* feat: add guest nickname handling

### Changed
* Add SPDX headers
* docs: Fix link to online docs
* test: Add missing tests for request token
* chore(deps): Bump @nextcloud/event-bus to 3.3.1
* Updated development dependencies