### PR TITLE
chore: 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.5.0 - 2025-05-12
+### Added
+* feat: add guest user by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-auth/pull/795
+
+### Fixed
+* fix: returns `NextcloudUser` instead of `GuestUser` by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-auth/pull/799
+
+### Changed
+* chore: Update workflows by @susnux in https://github.com/nextcloud-libraries/nextcloud-auth/pull/678
+* chore(deps-dev): Bump @nextcloud/eslint-config from 8.4.1 to 8.4.2 by @dependabot
+* chore(deps-dev): Bump @nextcloud/vite-config from 2.2.2 to 2.3.5 by @dependabot
+* chore(deps-dev): Bump @vitest/coverage-v8 from 2.0.5 to 2.1.8 by @dependabot
+* chore(deps-dev): Bump elliptic from 6.5.5 to 6.6.0 by @dependabot
+* chore(deps-dev): Bump eslint from 8.57.0 to 8.57.1 by @dependabot
+* chore(deps-dev): Bump happy-dom from 14.12.3 to 17.4.4 by @dependabot
+* chore(deps-dev): Bump typedoc from 0.26.10 to 0.28.4 by @dependabot
+* chore(deps-dev): Bump typescript from 5.5.4 to 5.8.3 by @dependabot
+* chore(deps-dev): Bump vite from 5.4.0 to 5.4.10 by @dependabot
+* chore(deps): Bump @nextcloud/event-bus from 3.3.1 to 3.3.2 by @dependabot
+* chore(deps): Bump rollup from 4.21.0 to 4.22.4 by @dependabot
+**Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-auth/compare/v2.4.0...v2.5.0
+
 ## 2.4.0 - 2024-08-13
 ### Added
 * feat: Add CSP nonce handling (`getCSPNonce`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/auth",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/auth",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/browser-storage": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/auth",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Nextcloud helpers related to authentication and the current user",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## 2.5.0 - 2025-05-12
### Added
* feat: add guest user by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-auth/pull/795

### Fixed
* fix: returns `NextcloudUser` instead of `GuestUser` by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-auth/pull/799

### Changed
* chore: Update workflows by @susnux in https://github.com/nextcloud-libraries/nextcloud-auth/pull/678
* chore(deps-dev): Bump @nextcloud/eslint-config from 8.4.1 to 8.4.2 by @dependabot
* chore(deps-dev): Bump @nextcloud/vite-config from 2.2.2 to 2.3.5 by @dependabot
* chore(deps-dev): Bump @vitest/coverage-v8 from 2.0.5 to 2.1.8 by @dependabot
* chore(deps-dev): Bump elliptic from 6.5.5 to 6.6.0 by @dependabot
* chore(deps-dev): Bump eslint from 8.57.0 to 8.57.1 by @dependabot
* chore(deps-dev): Bump happy-dom from 14.12.3 to 17.4.4 by @dependabot
* chore(deps-dev): Bump typedoc from 0.26.10 to 0.28.4 by @dependabot
* chore(deps-dev): Bump typescript from 5.5.4 to 5.8.3 by @dependabot
* chore(deps-dev): Bump vite from 5.4.0 to 5.4.10 by @dependabot
* chore(deps): Bump @nextcloud/event-bus from 3.3.1 to 3.3.2 by @dependabot
* chore(deps): Bump rollup from 4.21.0 to 4.22.4 by @dependabot

**Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-auth/compare/v2.4.0...v2.5.0
