### PR TITLE
chore: update supported node versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,7 @@
         "vitest": "^3.1.3"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,16 @@
     "vitest": "^3.1.3"
   },
   "engines": {
-    "node": "^20.0.0",
-    "npm": "^10.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": "^10.0.0"
+    },
+    "runtime": {
+      "name": "node",
+      "version": "^22.0.0"
+    }
   }
 }


### PR DESCRIPTION
As a library this should support multiple Nextcloud versions which might still use Node 20 (Nextcloud < 31) or Node 22 (Nextcloud 31) or even Node 24 which would be Nextcloud 32 or 33.
This package is not bound to Ndoe as this is a browser library, so we can even support all LTS versions.

Instead we only should ensure we have a consistent development engine.