### PR TITLE
chore: 2.6.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.6.0 - 2025-08-26
+## Changed
+* chore(deps): various minor/patch upgrades by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-auth/pull/827
+* ci: update reuse.yml workflow from template by @susnux in https://github.com/nextcloud-libraries/nextcloud-auth/pull/825
+* ci: update npm-publish.yml workflow from template by @susnux in https://github.com/nextcloud-libraries/nextcloud-auth/pull/826
+
 ## 2.5.2 - 2025-07-07
 ### Fixed
 * fix(files_sharing): fallback self.crypto.randomUUID by @skjnldsv in (#822)[https://github.com/nextcloud-libraries/nextcloud-auth/pull/822]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/auth",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/auth",
-      "version": "2.5.2",
+      "version": "2.6.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/browser-storage": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/auth",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "description": "Nextcloud helpers related to authentication and the current user",
   "keywords": [
     "nextcloud"


### PR DESCRIPTION
- [x] https://github.com/nextcloud-libraries/nextcloud-auth/pull/827

## 2.6.0 - 2025-08-26
## Changed
* chore(deps): various minor/patch upgrades by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-auth/pull/827
* ci: update reuse.yml workflow from template by @susnux in https://github.com/nextcloud-libraries/nextcloud-auth/pull/825
* ci: update npm-publish.yml workflow from template by @susnux in https://github.com/nextcloud-libraries/nextcloud-auth/pull/826
